### PR TITLE
Add Puppet 8 support. Add Debian 12. Update dependencies. Drop EOL versions.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7.3'
+          ruby-version: '3.2'
           bundler-cache: true
 
       - name: Run static validations
@@ -69,7 +69,7 @@ jobs:
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7.3'
+          ruby-version: '3.2'
           bundler-cache: true
 
       - name: Provision Testing Environments

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.2'
           bundler-cache: true
 
       - name: Build and Deploy

--- a/metadata.json
+++ b/metadata.json
@@ -10,23 +10,23 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 9.0.0"
+      "version_requirement": ">= 4.13.1 < 10.0.0"
     },
     {
       "name": "puppet-systemd",
-      "version_requirement": ">= 3.1.0 < 4.0.0"
+      "version_requirement": ">= 3.1.0 < 7.0.0"
     },
     {
       "name": "puppetlabs/inifile",
-      "version_requirement": ">= 1.6.0 < 6.0.0"
+      "version_requirement": ">= 1.6.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "11",
-        "10"
+        "12",
+        "11"
       ]
     },
     {
@@ -34,20 +34,12 @@
       "operatingsystemrelease": [
         "22.04",
         "20.04",
-        "18.04"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "8",
-        "7"
-      ]
-    },
-    {
-      "operatingsystem": "CentOS",
-      "operatingsystemrelease": [
-        "7"
+        "8"
       ]
     },
     {
@@ -69,7 +61,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.21.0 < 8.0.0"
+      "version_requirement": ">= 7.0.0 < 9.0.0"
     }
   ],
   "tags": [

--- a/metadata.json
+++ b/metadata.json
@@ -39,7 +39,8 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "8"
+        "8",
+        "7"
       ]
     },
     {

--- a/metadata.json
+++ b/metadata.json
@@ -33,7 +33,7 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "22.04",
-        "20.04",
+        "20.04"
       ]
     },
     {

--- a/provision.yaml
+++ b/provision.yaml
@@ -2,10 +2,7 @@
 default:
   provisioner: docker
   images:
-    - 'litmusimage/centos:7'
-    - 'litmusimage/debian:10'
     - 'litmusimage/debian:11'
-    - 'litmusimage/ubuntu:18.04'
     - 'litmusimage/ubuntu:20.04'
     - 'litmusimage/ubuntu:22.04'
     - 'litmusimage/almalinux:8'


### PR DESCRIPTION
- Add Puppet 8 support
- Drop Puppet 6 support
- Add Debian 12 
- Update dependency versions
- Drop CentOS support
- Drop Debian 10 support
- Drop Ubuntu 18.04 support